### PR TITLE
Remove static shape

### DIFF
--- a/models/IFRNet.py
+++ b/models/IFRNet.py
@@ -104,9 +104,9 @@ class Decoder3(nn.Module):
             nn.ConvTranspose2d(216, 52, 4, 2, 1, bias=True)
         )
 
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -121,9 +121,9 @@ class Decoder2(nn.Module):
             nn.ConvTranspose2d(144, 36, 4, 2, 1, bias=True)
         )
 
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -138,9 +138,9 @@ class Decoder1(nn.Module):
             nn.ConvTranspose2d(96, 8, 4, 2, 1, bias=True)
         )
         
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -158,7 +158,6 @@ class Model(nn.Module):
         self.tr_loss = Ternary(7)
         self.rb_loss = Charbonnier_Ada()
         self.gc_loss = Geometry(3)
-        self.up_flow_init_shape = [1,2,1088,1920]  # (B,C,H,W). Default. Change as needed
 
 
     def inference(self, img0, img1, embt, scale_factor=1.0):
@@ -177,28 +176,17 @@ class Model(nn.Module):
         up_flow1_4 = out4[:, 2:4]
         ft_3_ = out4[:, 4:]
 
-        up_flow_shape = self.up_flow_init_shape
-        up_flow_shape[2] = int(up_flow_shape[2] / 8)
-        up_flow_shape[3] = int(up_flow_shape[3] / 8)
-        # up_flow_shape = [int(x) for x in up_flow_shape]
-
-        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4, up_flow_shape)
+        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4)
         up_flow0_3 = out3[:, 0:2] + 2.0 * resize(up_flow0_4, scale_factor=2.0)
         up_flow1_3 = out3[:, 2:4] + 2.0 * resize(up_flow1_4, scale_factor=2.0)
         ft_2_ = out3[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3, up_flow_shape)
+        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3)
         up_flow0_2 = out2[:, 0:2] + 2.0 * resize(up_flow0_3, scale_factor=2.0)
         up_flow1_2 = out2[:, 2:4] + 2.0 * resize(up_flow1_3, scale_factor=2.0)
         ft_1_ = out2[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2, up_flow_shape)
+        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2)
         up_flow0_1 = out1[:, 0:2] + 2.0 * resize(up_flow0_2, scale_factor=2.0)
         up_flow1_1 = out1[:, 2:4] + 2.0 * resize(up_flow1_2, scale_factor=2.0)
         up_mask_1 = torch.sigmoid(out1[:, 4:5])
@@ -209,11 +197,8 @@ class Model(nn.Module):
         up_mask_1 = resize(up_mask_1, scale_factor=(1.0/scale_factor))
         up_res_1 = resize(up_res_1, scale_factor=(1.0/scale_factor))
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        img0_warp = warp(img0, up_flow0_1, up_flow_shape)
-        img1_warp = warp(img1, up_flow1_1, up_flow_shape)
+        img0_warp = warp(img0, up_flow0_1)
+        img1_warp = warp(img1, up_flow1_1)
         imgt_merge = up_mask_1 * img0_warp + (1 - up_mask_1) * img1_warp + mean_
         imgt_pred = imgt_merge + up_res_1
         imgt_pred = torch.clamp(imgt_pred, 0, 1)
@@ -235,38 +220,24 @@ class Model(nn.Module):
         up_flow1_4 = out4[:, 2:4]
         ft_3_ = out4[:, 4:]
 
-        up_flow_shape = self.up_flow_init_shape
-        up_flow_shape[2] = int(up_flow_shape[2] / 8)
-        up_flow_shape[3] = int(up_flow_shape[3] / 8)
-        # up_flow_shape = [int(x) for x in up_flow_shape]
-
-        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4, up_flow_shape)
+        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4)
         up_flow0_3 = out3[:, 0:2] + 2.0 * resize(up_flow0_4, scale_factor=2.0)
         up_flow1_3 = out3[:, 2:4] + 2.0 * resize(up_flow1_4, scale_factor=2.0)
         ft_2_ = out3[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3, up_flow_shape)
+        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3)
         up_flow0_2 = out2[:, 0:2] + 2.0 * resize(up_flow0_3, scale_factor=2.0)
         up_flow1_2 = out2[:, 2:4] + 2.0 * resize(up_flow1_3, scale_factor=2.0)
         ft_1_ = out2[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2, up_flow_shape)
+        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2)
         up_flow0_1 = out1[:, 0:2] + 2.0 * resize(up_flow0_2, scale_factor=2.0)
         up_flow1_1 = out1[:, 2:4] + 2.0 * resize(up_flow1_2, scale_factor=2.0)
         up_mask_1 = torch.sigmoid(out1[:, 4:5])
         up_res_1 = out1[:, 5:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        img0_warp = warp(img0, up_flow0_1, up_flow_shape)
-        img1_warp = warp(img1, up_flow1_1, up_flow_shape)
+        img0_warp = warp(img0, up_flow0_1)
+        img1_warp = warp(img1, up_flow1_1)
         imgt_merge = up_mask_1 * img0_warp + (1 - up_mask_1) * img1_warp + mean_
         imgt_pred = imgt_merge + up_res_1
         imgt_pred = torch.clamp(imgt_pred, 0, 1)

--- a/models/IFRNet_L.py
+++ b/models/IFRNet_L.py
@@ -104,9 +104,9 @@ class Decoder3(nn.Module):
             nn.ConvTranspose2d(432, 100, 4, 2, 1, bias=True)
         )
 
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -121,9 +121,9 @@ class Decoder2(nn.Module):
             nn.ConvTranspose2d(288, 68, 4, 2, 1, bias=True)
         )
 
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -138,9 +138,9 @@ class Decoder1(nn.Module):
             nn.ConvTranspose2d(192, 8, 4, 2, 1, bias=True)
         )
 
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -158,7 +158,6 @@ class Model(nn.Module):
         self.tr_loss = Ternary(7)
         self.rb_loss = Charbonnier_Ada()
         self.gc_loss = Geometry(3)
-        self.up_flow_init_shape = [1,2,1088,1920]  # (B,C,H,W). Default. Change as needed
 
 
     def inference(self, img0, img1, embt, scale_factor=1.0):
@@ -177,28 +176,17 @@ class Model(nn.Module):
         up_flow1_4 = out4[:, 2:4]
         ft_3_ = out4[:, 4:]
 
-        up_flow_shape = self.up_flow_init_shape
-        up_flow_shape[2] = int(up_flow_shape[2] / 8)
-        up_flow_shape[3] = int(up_flow_shape[3] / 8)
-        # up_flow_shape = [int(x) for x in up_flow_shape]
-
-        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4, up_flow_shape)
+        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4)
         up_flow0_3 = out3[:, 0:2] + 2.0 * resize(up_flow0_4, scale_factor=2.0)
         up_flow1_3 = out3[:, 2:4] + 2.0 * resize(up_flow1_4, scale_factor=2.0)
         ft_2_ = out3[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3, up_flow_shape)
+        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3)
         up_flow0_2 = out2[:, 0:2] + 2.0 * resize(up_flow0_3, scale_factor=2.0)
         up_flow1_2 = out2[:, 2:4] + 2.0 * resize(up_flow1_3, scale_factor=2.0)
         ft_1_ = out2[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2, up_flow_shape)
+        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2)
         up_flow0_1 = out1[:, 0:2] + 2.0 * resize(up_flow0_2, scale_factor=2.0)
         up_flow1_1 = out1[:, 2:4] + 2.0 * resize(up_flow1_2, scale_factor=2.0)
         up_mask_1 = torch.sigmoid(out1[:, 4:5])
@@ -209,11 +197,8 @@ class Model(nn.Module):
         up_mask_1 = resize(up_mask_1, scale_factor=(1.0/scale_factor))
         up_res_1 = resize(up_res_1, scale_factor=(1.0/scale_factor))
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        img0_warp = warp(img0, up_flow0_1, up_flow_shape)
-        img1_warp = warp(img1, up_flow1_1, up_flow_shape)
+        img0_warp = warp(img0, up_flow0_1)
+        img1_warp = warp(img1, up_flow1_1)
         imgt_merge = up_mask_1 * img0_warp + (1 - up_mask_1) * img1_warp + mean_
         imgt_pred = imgt_merge + up_res_1
         imgt_pred = torch.clamp(imgt_pred, 0, 1)
@@ -235,38 +220,24 @@ class Model(nn.Module):
         up_flow1_4 = out4[:, 2:4]
         ft_3_ = out4[:, 4:]
 
-        up_flow_shape = self.up_flow_init_shape
-        up_flow_shape[2] = int(up_flow_shape[2] / 8)
-        up_flow_shape[3] = int(up_flow_shape[3] / 8)
-        # up_flow_shape = [int(x) for x in up_flow_shape]
-
-        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4, up_flow_shape)
+        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4)
         up_flow0_3 = out3[:, 0:2] + 2.0 * resize(up_flow0_4, scale_factor=2.0)
         up_flow1_3 = out3[:, 2:4] + 2.0 * resize(up_flow1_4, scale_factor=2.0)
         ft_2_ = out3[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3, up_flow_shape)
+        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3)
         up_flow0_2 = out2[:, 0:2] + 2.0 * resize(up_flow0_3, scale_factor=2.0)
         up_flow1_2 = out2[:, 2:4] + 2.0 * resize(up_flow1_3, scale_factor=2.0)
         ft_1_ = out2[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2, up_flow_shape)
+        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2)
         up_flow0_1 = out1[:, 0:2] + 2.0 * resize(up_flow0_2, scale_factor=2.0)
         up_flow1_1 = out1[:, 2:4] + 2.0 * resize(up_flow1_2, scale_factor=2.0)
         up_mask_1 = torch.sigmoid(out1[:, 4:5])
         up_res_1 = out1[:, 5:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        img0_warp = warp(img0, up_flow0_1, up_flow_shape)
-        img1_warp = warp(img1, up_flow1_1, up_flow_shape)
+        img0_warp = warp(img0, up_flow0_1)
+        img1_warp = warp(img1, up_flow1_1)
         imgt_merge = up_mask_1 * img0_warp + (1 - up_mask_1) * img1_warp + mean_
         imgt_pred = imgt_merge + up_res_1
         imgt_pred = torch.clamp(imgt_pred, 0, 1)

--- a/models/IFRNet_S.py
+++ b/models/IFRNet_S.py
@@ -104,9 +104,9 @@ class Decoder3(nn.Module):
             nn.ConvTranspose2d(162, 40, 4, 2, 1, bias=True)
         )
 
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -121,9 +121,9 @@ class Decoder2(nn.Module):
             nn.ConvTranspose2d(108, 28, 4, 2, 1, bias=True)
         )
 
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -138,9 +138,9 @@ class Decoder1(nn.Module):
             nn.ConvTranspose2d(72, 8, 4, 2, 1, bias=True)
         )
         
-    def forward(self, ft_, f0, f1, up_flow0, up_flow1, up_flow_shape):
-        f0_warp = warp(f0, up_flow0, up_flow_shape)
-        f1_warp = warp(f1, up_flow1, up_flow_shape)
+    def forward(self, ft_, f0, f1, up_flow0, up_flow1):
+        f0_warp = warp(f0, up_flow0)
+        f1_warp = warp(f1, up_flow1)
         f_in = torch.cat([ft_, f0_warp, f1_warp, up_flow0, up_flow1], 1)
         f_out = self.convblock(f_in)
         return f_out
@@ -158,7 +158,6 @@ class Model(nn.Module):
         self.tr_loss = Ternary(7)
         self.rb_loss = Charbonnier_Ada()
         self.gc_loss = Geometry(3)
-        self.up_flow_init_shape = [1,2,1088,1920]  # (B,C,H,W). Default. Change as needed
 
 
     def inference(self, img0, img1, embt, scale_factor=1.0):
@@ -177,28 +176,17 @@ class Model(nn.Module):
         up_flow1_4 = out4[:, 2:4]
         ft_3_ = out4[:, 4:]
 
-        up_flow_shape = self.up_flow_init_shape
-        up_flow_shape[2] = int(up_flow_shape[2] / 8)
-        up_flow_shape[3] = int(up_flow_shape[3] / 8)
-        # up_flow_shape = [int(x) for x in up_flow_shape]
-
-        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4, up_flow_shape)
+        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4)
         up_flow0_3 = out3[:, 0:2] + 2.0 * resize(up_flow0_4, scale_factor=2.0)
         up_flow1_3 = out3[:, 2:4] + 2.0 * resize(up_flow1_4, scale_factor=2.0)
         ft_2_ = out3[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3, up_flow_shape)
+        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3)
         up_flow0_2 = out2[:, 0:2] + 2.0 * resize(up_flow0_3, scale_factor=2.0)
         up_flow1_2 = out2[:, 2:4] + 2.0 * resize(up_flow1_3, scale_factor=2.0)
         ft_1_ = out2[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2, up_flow_shape)
+        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2)
         up_flow0_1 = out1[:, 0:2] + 2.0 * resize(up_flow0_2, scale_factor=2.0)
         up_flow1_1 = out1[:, 2:4] + 2.0 * resize(up_flow1_2, scale_factor=2.0)
         up_mask_1 = torch.sigmoid(out1[:, 4:5])
@@ -209,11 +197,8 @@ class Model(nn.Module):
         up_mask_1 = resize(up_mask_1, scale_factor=(1.0/scale_factor))
         up_res_1 = resize(up_res_1, scale_factor=(1.0/scale_factor))
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        img0_warp = warp(img0, up_flow0_1, up_flow_shape)
-        img1_warp = warp(img1, up_flow1_1, up_flow_shape)
+        img0_warp = warp(img0, up_flow0_1)
+        img1_warp = warp(img1, up_flow1_1)
         imgt_merge = up_mask_1 * img0_warp + (1 - up_mask_1) * img1_warp + mean_
         imgt_pred = imgt_merge + up_res_1
         imgt_pred = torch.clamp(imgt_pred, 0, 1)
@@ -235,38 +220,24 @@ class Model(nn.Module):
         up_flow1_4 = out4[:, 2:4]
         ft_3_ = out4[:, 4:]
 
-        up_flow_shape = self.up_flow_init_shape
-        up_flow_shape[2] = int(up_flow_shape[2] / 8)
-        up_flow_shape[3] = int(up_flow_shape[3] / 8)
-        # up_flow_shape = [int(x) for x in up_flow_shape]
-
-        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4, up_flow_shape)
+        out3 = self.decoder3(ft_3_, f0_3, f1_3, up_flow0_4, up_flow1_4)
         up_flow0_3 = out3[:, 0:2] + 2.0 * resize(up_flow0_4, scale_factor=2.0)
         up_flow1_3 = out3[:, 2:4] + 2.0 * resize(up_flow1_4, scale_factor=2.0)
         ft_2_ = out3[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3, up_flow_shape)
+        out2 = self.decoder2(ft_2_, f0_2, f1_2, up_flow0_3, up_flow1_3)
         up_flow0_2 = out2[:, 0:2] + 2.0 * resize(up_flow0_3, scale_factor=2.0)
         up_flow1_2 = out2[:, 2:4] + 2.0 * resize(up_flow1_3, scale_factor=2.0)
         ft_1_ = out2[:, 4:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2, up_flow_shape)
+        out1 = self.decoder1(ft_1_, f0_1, f1_1, up_flow0_2, up_flow1_2)
         up_flow0_1 = out1[:, 0:2] + 2.0 * resize(up_flow0_2, scale_factor=2.0)
         up_flow1_1 = out1[:, 2:4] + 2.0 * resize(up_flow1_2, scale_factor=2.0)
         up_mask_1 = torch.sigmoid(out1[:, 4:5])
         up_res_1 = out1[:, 5:]
 
-        up_flow_shape[2] *= 2
-        up_flow_shape[3] *= 2
-
-        img0_warp = warp(img0, up_flow0_1, up_flow_shape)
-        img1_warp = warp(img1, up_flow1_1, up_flow_shape)
+        img0_warp = warp(img0, up_flow0_1)
+        img1_warp = warp(img1, up_flow1_1)
         imgt_merge = up_mask_1 * img0_warp + (1 - up_mask_1) * img1_warp + mean_
         imgt_pred = imgt_merge + up_res_1
         imgt_pred = torch.clamp(imgt_pred, 0, 1)

--- a/utils.py
+++ b/utils.py
@@ -11,15 +11,19 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-def warp(img, flow, flow_shape):
-    # B, _, H, W = flow_shape
-    xx = torch.linspace(-1.0, 1.0, flow_shape[3]).view(1, 1, 1, flow_shape[3]).expand(flow_shape[0], -1, flow_shape[2], -1)
-    yy = torch.linspace(-1.0, 1.0, flow_shape[2]).view(1, 1, flow_shape[2], 1).expand(flow_shape[0], -1, -1, flow_shape[3])
-    grid = torch.cat([xx, yy], 1).to(img)
-    flow_ = torch.cat([flow[:, 0:1, :, :] / ((flow_shape[3] - 1.0) / 2.0), flow[:, 1:2, :, :] / ((flow_shape[2] - 1.0) / 2.0)], 1)
-    grid_ = (grid + flow_).permute(0, 2, 3, 1)
-    output = F.grid_sample(input=img, grid=grid_, mode='bilinear', padding_mode='border', align_corners=True)
-    return output
+def warp(img, flow):
+    if not isinstance(flow, torch.fx.Proxy):
+        B, _, H, W = flow.shape
+        xx = torch.linspace(-1.0, 1.0, W).view(1, 1, 1, W).expand(B, -1, H, -1)
+        yy = torch.linspace(-1.0, 1.0, H).view(1, 1, H, 1).expand(B, -1, -1, W)
+        grid = torch.cat([xx, yy], 1).to(img)
+        flow_ = torch.cat([flow[:, 0:1, :, :] / ((W - 1.0) / 2.0), flow[:, 1:2, :, :] / ((H - 1.0) / 2.0)], 1)
+        grid_ = (grid + flow_).permute(0, 2, 3, 1)
+        output = F.grid_sample(input=img, grid=grid_, mode='bilinear', padding_mode='border', align_corners=True)
+        return output
+    # return img when converting to timeloop problems, since we only care about 
+    # convolutions in hw metrics
+    return img 
 
 
 def get_robust_weight(flow_pred, flow_gt, beta):


### PR DESCRIPTION
* remove 'shape' attribute that was used when converting from PyTorch to Timeloop by skipping the 'warping' functions during conversion, since we only care about convolutions when getting hardware metrics